### PR TITLE
Fix monitor targeting logic to account for facing direction

### DIFF
--- a/src/main/java/com/happysg/radar/block/monitor/MonitorBlock.java
+++ b/src/main/java/com/happysg/radar/block/monitor/MonitorBlock.java
@@ -54,7 +54,7 @@ public class MonitorBlock extends HorizontalDirectionalBlock implements IBE<Moni
     public InteractionResult use(BlockState pState, Level pLevel, BlockPos pPos, Player pPlayer, InteractionHand pHand, BlockHitResult pHit) {
         if (!pPlayer.getMainHandItem().isEmpty() || pHand == InteractionHand.OFF_HAND)
             return InteractionResult.PASS;
-        return onBlockEntityUse(pLevel, pPos, monitorBlockEntity -> monitorBlockEntity.getController().onUse(pPlayer, pHand, pHit));
+        return onBlockEntityUse(pLevel, pPos, monitorBlockEntity -> monitorBlockEntity.getController().onUse(pPlayer, pHand, pHit, pState.getValue(FACING)));
     }
 
     public enum Shape implements StringRepresentable {

--- a/src/main/java/com/happysg/radar/block/monitor/MonitorBlockEntity.java
+++ b/src/main/java/com/happysg/radar/block/monitor/MonitorBlockEntity.java
@@ -145,12 +145,12 @@ public class MonitorBlockEntity extends SmartBlockEntity implements IHaveHoverin
         if (pPlayer.isShiftKeyDown()) {
             selectedEntity = null;
         } else {
-            setSelectedEntity(pHit.getLocation());
+            setSelectedEntity(pHit.getLocation(), pHit.getDirection(), pHit.getDirection());
         }
         return InteractionResult.SUCCESS;
     }
 
-    private void setSelectedEntity(Vec3 location) {
+    private void setSelectedEntity(Vec3 location, Direction blockFacing, Direction monitorFacing) {
         if (level.isClientSide())
             return;
         if (radarPos == null)
@@ -162,6 +162,7 @@ public class MonitorBlockEntity extends SmartBlockEntity implements IHaveHoverin
                 .add(facing.getStepX() * (size - 1) / 2.0, (size - 1) / 2.0, facing.getStepZ() * (size - 1) / 2.0);
         Vec3 relative = location.subtract(center);
         relative = new Vec3(facing.getAxis() == Direction.Axis.Z ? relative.y() : relative.x(), 0, facing.getAxis() == Direction.Axis.X ? -relative.y() : relative.z());
+        relative = adjustRelativeVectorForFacing(relative, blockFacing, monitorFacing);
         System.out.println("relative = " + relative);
         Vec3 RadarPos = radarPos.getCenter();
         float range = getRadar().map(RadarBearingBlockEntity::getRange).orElse(0f);
@@ -184,6 +185,21 @@ public class MonitorBlockEntity extends SmartBlockEntity implements IHaveHoverin
                         }
                     }
                 });
+    }
+
+    private Vec3 adjustRelativeVectorForFacing(Vec3 relative, Direction blockFacing, Direction monitorFacing) {
+        switch (monitorFacing) {
+            case NORTH:
+                return new Vec3(-relative.x(), relative.y(), -relative.z());
+            case SOUTH:
+                return relative;
+            case WEST:
+                return new Vec3(relative.z(), relative.y(), -relative.x());
+            case EAST:
+                return new Vec3(-relative.z(), relative.y(), relative.x());
+            default:
+                return relative;
+        }
     }
 
     public MonitorBlockEntity getController() {


### PR DESCRIPTION
COPILOT TEST

Update the targeting logic for the monitor block to account for the monitor's facing direction and translate the clicked point on the block to the actual world chosen entity.

* Modify `MonitorBlockEntity.java`:
  - Update the `setSelectedEntity` method to accept blockFacing and monitorFacing parameters.
  - Adjust the calculation of the `relative` vector to consider the monitor's facing direction.
  - Add a new method `adjustRelativeVectorForFacing` to handle the transformation of the `relative` vector based on the monitor's facing direction.

* Modify `MonitorBlock.java`:
  - Update the `use` method to pass the block's facing direction to the `MonitorBlockEntity`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Arsenalists-of-Create/Create-Radar/pull/1?shareId=bba28bf7-3351-4a7e-aa10-4a1f8f076147).