### PR TITLE
Fix Auto Targeting Screen on Auto Pitch Controller DataLink

### DIFF
--- a/src/main/java/com/happysg/radar/block/controller/pitch/PitchLinkBehavior.java
+++ b/src/main/java/com/happysg/radar/block/controller/pitch/PitchLinkBehavior.java
@@ -26,7 +26,7 @@ public class PitchLinkBehavior extends DataPeripheral {
         if (!(context.getSourceBlockEntity() instanceof AutoPitchControllerBlockEntity controller))
             return;
 
-        if (context.getMonitorBlockEntity() == null)
+        if (context.getMonitorBlockEntity() == null || context.level().isClientSide())
             return;
 
         MonitorBlockEntity monitor = context.getMonitorBlockEntity();

--- a/src/main/java/com/happysg/radar/block/datalink/screens/AbstractDataLinkScreen.java
+++ b/src/main/java/com/happysg/radar/block/datalink/screens/AbstractDataLinkScreen.java
@@ -51,7 +51,6 @@ public class AbstractDataLinkScreen extends AbstractSimiScreen {
         int x = guiLeft;
         int y = guiTop;
 
-
         initGathererOptions();
 
         confirmButton = new IconButton(x + background.width - 33, y + background.height - 24, AllIcons.I_CONFIRM);
@@ -65,14 +64,11 @@ public class AbstractDataLinkScreen extends AbstractSimiScreen {
         sourceState = level.getBlockState(blockEntity.getSourcePosition());
         targetState = level.getBlockState(blockEntity.getTargetPosition());
 
-        ItemStack asItem;
         int x = guiLeft;
         int y = guiTop;
 
-
         source = AllDataBehaviors.sourcesOf(level, blockEntity.getSourcePosition());
         target = AllDataBehaviors.targetOf(level, blockEntity.getTargetPosition());
-
     }
 
 
@@ -118,7 +114,4 @@ public class AbstractDataLinkScreen extends AbstractSimiScreen {
 
     public void onClose(CompoundTag tag) {
     }
-
-    ;
-
 }

--- a/src/main/java/com/happysg/radar/block/datalink/screens/AutoTargetScreen.java
+++ b/src/main/java/com/happysg/radar/block/datalink/screens/AutoTargetScreen.java
@@ -133,6 +133,5 @@ public class AutoTargetScreen extends AbstractDataLinkScreen {
         super.onClose(tag);
         TargetingConfig targetingConfig = new TargetingConfig(player, contraption, mob, animal, projectile, autoTarget, autoFire);
         tag.put("targeting", targetingConfig.toTag());
-        System.out.println("onClose: " + targetingConfig.toTag());
     }
 }

--- a/src/main/java/com/happysg/radar/block/datalink/screens/AutoTargetScreen.java
+++ b/src/main/java/com/happysg/radar/block/datalink/screens/AutoTargetScreen.java
@@ -38,7 +38,7 @@ public class AutoTargetScreen extends AbstractDataLinkScreen {
         this.background = ModGuiTextures.CANNON_TARGETING;
         TargetingConfig targetingConfig = TargetingConfig.DEFAULT;
         if (be.getSourceConfig().contains("targeting")) {
-            targetingConfig = TargetingConfig.fromTag(be.getSourceConfig().getCompound("targeting"));
+            targetingConfig = TargetingConfig.fromTag(be.getSourceConfig());
         }
         player = targetingConfig.player();
         contraption = targetingConfig.contraption();
@@ -133,5 +133,6 @@ public class AutoTargetScreen extends AbstractDataLinkScreen {
         super.onClose(tag);
         TargetingConfig targetingConfig = new TargetingConfig(player, contraption, mob, animal, projectile, autoTarget, autoFire);
         tag.put("targeting", targetingConfig.toTag());
+        System.out.println("onClose: " + targetingConfig.toTag());
     }
 }


### PR DESCRIPTION
When using datalink on a auto pitch controller the state of the screen would always populate a default `TargetingConfig`. 

This was due to constructing `TargetingConfig` using the `fromTag()` being passed a parsed compound tag that just pulled the targeting nbt data required when the `fromTag()` method already did that.

Also a little cleanup.


https://github.com/user-attachments/assets/43c79661-c315-40ec-b850-d20abbb2f1c9

