### PR TITLE
Performance Improvements to Radar Tracks

### DIFF
--- a/src/main/java/com/happysg/radar/block/controller/pitch/AutoPitchControllerBlockEntity.java
+++ b/src/main/java/com/happysg/radar/block/controller/pitch/AutoPitchControllerBlockEntity.java
@@ -24,7 +24,7 @@ public class AutoPitchControllerBlockEntity extends KineticBlockEntity {
     private static final double TOLERANCE = 0.1;
     private double targetAngle;
     private boolean isRunning;
-    private boolean artillery =  false;
+    private boolean artillery = false;
 
     //abstract class for firing control to avoid cluttering pitch logic
     public FiringControlBlockEntity firingControl;

--- a/src/main/java/com/happysg/radar/block/radar/behavior/RadarScanningBlockBehavior.java
+++ b/src/main/java/com/happysg/radar/block/radar/behavior/RadarScanningBlockBehavior.java
@@ -71,13 +71,9 @@ public class RadarScanningBlockBehavior extends BlockEntityBehaviour {
         if (level == null) return;
         for (Entity entity : scannedEntities) {
             if (entity.isAlive() && isInFovAndRange(entity.position())) {
-                // RadarTrack track = new RadarTrack(entity);
-                // radarTracks.put(track.getId(), track);
                 if (radarTracks.containsKey(entity.getUUID().toString())) {
                     RadarTrack track = radarTracks.get(entity.getUUID().toString());
-                    track.setPosition(entity.position());
-                    track.setVelocity(entity.getDeltaMovement());
-                    track.setScannedTime(entity.level().getGameTime());
+                    track.updateRadarTrack(entity);
                 } else {
                     RadarTrack track = new RadarTrack(entity);
                     radarTracks.put(track.getId(), track);
@@ -88,13 +84,14 @@ public class RadarScanningBlockBehavior extends BlockEntityBehaviour {
         }
         for (Ship ship : scannedShips) {
             if (isInFovAndRange(RadarTrackUtil.getPosition(ship))) {
-                RadarTrack track = RadarTrackUtil.getRadarTrack(ship, level);
-                radarTracks.put(track.getId(), track);
+                if (radarTracks.containsKey(ship.getSlug())) {
+                    RadarTrack track = radarTracks.get(ship.getSlug());
+                    track.updateRadarTrack(ship, level);
+                } else {
+                    RadarTrack track = RadarTrackUtil.getRadarTrack(ship, level);
+                    radarTracks.put(track.getId(), track);
+                }
             }
-        }
-        for (Projectile projectile : scannedProjectiles) {
-            RadarTrack track = new RadarTrack(projectile);
-            radarTracks.put(track.getId(), track);
         }
     }
 

--- a/src/main/java/com/happysg/radar/block/radar/behavior/RadarScanningBlockBehavior.java
+++ b/src/main/java/com/happysg/radar/block/radar/behavior/RadarScanningBlockBehavior.java
@@ -70,9 +70,18 @@ public class RadarScanningBlockBehavior extends BlockEntityBehaviour {
         Level level = blockEntity.getLevel();
         if (level == null) return;
         for (Entity entity : scannedEntities) {
-            if (entity.isAlive() && isInFovAndRange(entity.position()) && !radarTracks.containsKey(entity.getUUID().toString())) {
-                RadarTrack track = new RadarTrack(entity);
-                radarTracks.put(track.id(), track);
+            if (entity.isAlive() && isInFovAndRange(entity.position())) {
+                // RadarTrack track = new RadarTrack(entity);
+                // radarTracks.put(track.getId(), track);
+                if (radarTracks.containsKey(entity.getUUID().toString())) {
+                    RadarTrack track = radarTracks.get(entity.getUUID().toString());
+                    track.setPosition(entity.position());
+                    track.setVelocity(entity.getDeltaMovement());
+                    track.setScannedTime(entity.level().getGameTime());
+                } else {
+                    RadarTrack track = new RadarTrack(entity);
+                    radarTracks.put(track.getId(), track);
+                }
                 if (entity instanceof Projectile)
                     scannedProjectiles.add((Projectile) entity);
             }
@@ -80,12 +89,12 @@ public class RadarScanningBlockBehavior extends BlockEntityBehaviour {
         for (Ship ship : scannedShips) {
             if (isInFovAndRange(RadarTrackUtil.getPosition(ship))) {
                 RadarTrack track = RadarTrackUtil.getRadarTrack(ship, level);
-                radarTracks.put(track.id(), track);
+                radarTracks.put(track.getId(), track);
             }
         }
         for (Projectile projectile : scannedProjectiles) {
             RadarTrack track = new RadarTrack(projectile);
-            radarTracks.put(track.id(), track);
+            radarTracks.put(track.getId(), track);
         }
     }
 

--- a/src/main/java/com/happysg/radar/block/radar/track/RadarTrack.java
+++ b/src/main/java/com/happysg/radar/block/radar/track/RadarTrack.java
@@ -8,8 +8,22 @@ import net.minecraft.world.entity.Entity;
 import net.minecraft.world.phys.Vec3;
 
 
-public record RadarTrack(String id, Vec3 position, Vec3 velocity, long scannedTime,
-                         TrackCategory trackCategory, String entityType) {
+public class RadarTrack {
+    private final String id;
+    private Vec3 position;
+    private Vec3 velocity;
+    private long scannedTime;
+    private final TrackCategory trackCategory;
+    private final String entityType;
+
+    public RadarTrack(String id, Vec3 position, Vec3 velocity, long scannedTime, TrackCategory trackCategory, String entityType) {
+        this.id = id;
+        this.position = position;
+        this.velocity = velocity;
+        this.scannedTime = scannedTime;
+        this.trackCategory = trackCategory;
+        this.entityType = entityType;
+    }
 
     public RadarTrack(Entity entity) {
         this(entity.getUUID().toString(), entity.position(), entity.getDeltaMovement(), entity.level().getGameTime(),
@@ -62,5 +76,39 @@ public record RadarTrack(String id, Vec3 position, Vec3 velocity, long scannedTi
         return tag;
     }
 
+    public String getId() {
+        return id;
+    }
 
+    public Vec3 getPosition() {
+        return position;
+    }
+
+    public void setPosition(Vec3 position) {
+        this.position = position;
+    }
+
+    public Vec3 getVelocity() {
+        return velocity;
+    }
+
+    public void setVelocity(Vec3 velocity) {
+        this.velocity = velocity;
+    }
+
+    public long getScannedTime() {
+        return scannedTime;
+    }
+
+    public void setScannedTime(long scannedTime) {
+        this.scannedTime = scannedTime;
+    }
+
+    public TrackCategory getTrackCategory() {
+        return trackCategory;
+    }
+
+    public String getEntityType() {
+        return entityType;
+    }
 }

--- a/src/main/java/com/happysg/radar/block/radar/track/RadarTrack.java
+++ b/src/main/java/com/happysg/radar/block/radar/track/RadarTrack.java
@@ -5,7 +5,9 @@ import com.happysg.radar.config.RadarConfig;
 import com.jozufozu.flywheel.util.Color;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.world.entity.Entity;
+import net.minecraft.world.level.Level;
 import net.minecraft.world.phys.Vec3;
+import org.valkyrienskies.core.api.ships.Ship;
 
 
 public class RadarTrack {
@@ -76,6 +78,18 @@ public class RadarTrack {
         return tag;
     }
 
+    public void updateRadarTrack(Entity entity) {
+        position = entity.position();
+        velocity = entity.getDeltaMovement();
+        scannedTime = entity.level().getGameTime();
+    }
+
+    public void updateRadarTrack(Ship ship, Level level) {
+        position = RadarTrackUtil.getPosition(ship);
+        velocity = RadarTrackUtil.getVelocity(ship);
+        scannedTime = level.getGameTime();
+    }
+
     public String getId() {
         return id;
     }
@@ -110,5 +124,25 @@ public class RadarTrack {
 
     public String getEntityType() {
         return entityType;
+    }
+
+    // This is a bit of a jank quick fix, since ive migrated from a record.
+    public String id() {
+        return getId();
+    }
+    public Vec3 position() {
+        return getPosition();
+    }
+    public Vec3 velocity() {
+        return getVelocity();
+    }
+    public long scannedTime() {
+        return getScannedTime();
+    }
+    public TrackCategory trackCategory() {
+        return getTrackCategory();
+    }
+    public String entityType() {
+        return getEntityType();
     }
 }

--- a/src/main/java/com/happysg/radar/compat/computercraft/CCCompatRegister.java
+++ b/src/main/java/com/happysg/radar/compat/computercraft/CCCompatRegister.java
@@ -8,5 +8,7 @@ public class CCCompatRegister {
         CreateRadar.getLogger().info("Registering Peripherals!");
         ComputerCraftAPI.registerGenericSource(new RadarBearingPeripheral());
         ComputerCraftAPI.registerGenericSource(new MonitorPeripheral());
+        ComputerCraftAPI.registerGenericSource(new YawControllerPeripheral());
+        ComputerCraftAPI.registerGenericSource(new PitchControllerPeripheral());
     }
 }

--- a/src/main/java/com/happysg/radar/compat/computercraft/PitchControllerPeripheral.java
+++ b/src/main/java/com/happysg/radar/compat/computercraft/PitchControllerPeripheral.java
@@ -12,17 +12,17 @@ public class PitchControllerPeripheral implements GenericPeripheral {
         return CreateRadar.asResource("pitch_controller").toString();
     }
 
-    @LuaFunction
+    @LuaFunction(mainThread = true)
     public void setTargetPosition(AutoPitchControllerBlockEntity entity, double x, double y, double z) {
         entity.setTarget(new Vec3(x, y, z));
     }
 
-    @LuaFunction
+    @LuaFunction(mainThread = true)
     public void setTargetAngle(AutoPitchControllerBlockEntity entity, float angle) {
         entity.setTargetAngle(angle);
     }
 
-    @LuaFunction
+    @LuaFunction(mainThread = true)
     public double getTargetAngle(AutoPitchControllerBlockEntity entity){
         return entity.getTargetAngle();
     }

--- a/src/main/java/com/happysg/radar/compat/computercraft/YawControllerPeripheral.java
+++ b/src/main/java/com/happysg/radar/compat/computercraft/YawControllerPeripheral.java
@@ -12,17 +12,17 @@ public class YawControllerPeripheral implements GenericPeripheral {
         return CreateRadar.asResource("yaw_controller").toString();
     }
 
-    @LuaFunction
+    @LuaFunction(mainThread = true)
     public void setTargetPosition(AutoYawControllerBlockEntity entity, double x, double y, double z) {
         entity.setTarget(new Vec3(x, y, z));
     }
 
-    @LuaFunction
+    @LuaFunction(mainThread = true)
     public void setTargetAngle(AutoYawControllerBlockEntity entity, float angle) {
         entity.setTargetAngle(angle);
     }
 
-    @LuaFunction
+    @LuaFunction(mainThread = true)
     public double getTargetAngle(AutoYawControllerBlockEntity entity){
         return entity.getTargetAngle();
     }


### PR DESCRIPTION
Previously RadarTracks would be created every tick for every entity a radar could see, this created an excessive amount of RadarTracks that the garbage collector would have to clean up. 

This PR helps fix that by making radars update already existing RadarTracks instead of replacing them with new ones every tick. It also corrects some broken peripheral code

Changes:
- Migrated RadarTrack from a record to a class
- Modified RadarScanningBlockBehavior to check for and update existing tracks.
- Added Auto Yaw and Pitch peripherals to the registry
- Made all peripherals operate on the mainThread