### PR TITLE
Fix server side crashing

### DIFF
--- a/src/main/java/com/happysg/radar/item/detectionfilter/DetectionFilterItem.java
+++ b/src/main/java/com/happysg/radar/item/detectionfilter/DetectionFilterItem.java
@@ -8,18 +8,25 @@ import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
 
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.api.distmarker.OnlyIn;
+
 public class DetectionFilterItem extends Item {
 
     public DetectionFilterItem(Properties properties) {
         super(properties);
     }
 
+    @OnlyIn(Dist.CLIENT)
+    private InteractionResultHolder<ItemStack> clientFunc(Level level, Player player, InteractionHand hand) {
+        Minecraft.getInstance().setScreen(new RadarFilterScreen());
+        return InteractionResultHolder.success(player.getItemInHand(hand));
+    }
+
     @Override
     public InteractionResultHolder<ItemStack> use(Level level, Player player, InteractionHand hand) {
         if (!level.isClientSide)
             return InteractionResultHolder.pass(player.getItemInHand(hand));
-
-        Minecraft.getInstance().setScreen(new RadarFilterScreen());
-        return InteractionResultHolder.success(player.getItemInHand(hand));
+        return clientFunc(level, player, hand);
     }
 }

--- a/src/main/java/com/happysg/radar/item/identfilter/IdentFilterItem.java
+++ b/src/main/java/com/happysg/radar/item/identfilter/IdentFilterItem.java
@@ -8,18 +8,25 @@ import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
 
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.api.distmarker.OnlyIn;
+
 public class IdentFilterItem extends Item {
     public IdentFilterItem(Properties properties) {
         super(properties);
+    }
+
+    @OnlyIn(Dist.CLIENT)
+    private InteractionResultHolder<ItemStack> clientFunc(Level level, Player player, InteractionHand hand) {
+        Minecraft.getInstance().setScreen(new IdentificationFilterScreen());
+        return InteractionResultHolder.success(player.getItemInHand(hand));
     }
 
     @Override
     public InteractionResultHolder<ItemStack> use(Level level, Player player, InteractionHand hand) {
         if (!level.isClientSide)
             return InteractionResultHolder.pass(player.getItemInHand(hand));
-
-        Minecraft.getInstance().setScreen(new IdentificationFilterScreen());
-        return InteractionResultHolder.success(player.getItemInHand(hand));
+        return clientFunc(level, player, hand);
     }
 }
 

--- a/src/main/java/com/happysg/radar/item/targetfilter/TargetFilterItem.java
+++ b/src/main/java/com/happysg/radar/item/targetfilter/TargetFilterItem.java
@@ -8,18 +8,25 @@ import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
 
-public class TargetFilterItem extends Item{
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.api.distmarker.OnlyIn;
 
-        public TargetFilterItem(Properties properties) {
-            super(properties);
-        }
+public class TargetFilterItem extends Item {
 
-        @Override
-        public InteractionResultHolder<ItemStack> use(Level level, Player player, InteractionHand hand) {
-            if (!level.isClientSide)
-                return InteractionResultHolder.pass(player.getItemInHand(hand));
-
-            Minecraft.getInstance().setScreen(new AutoTargetScreen());
-            return InteractionResultHolder.success(player.getItemInHand(hand));
-        }
+    public TargetFilterItem(Properties properties) {
+        super(properties);
     }
+
+    @OnlyIn(Dist.CLIENT)
+    private InteractionResultHolder<ItemStack> clientFunc(Level level, Player player, InteractionHand hand) {
+        Minecraft.getInstance().setScreen(new AutoTargetScreen());
+        return InteractionResultHolder.success(player.getItemInHand(hand));
+    }
+
+    @Override
+    public InteractionResultHolder<ItemStack> use(Level level, Player player, InteractionHand hand) {
+        if (!level.isClientSide)
+            return InteractionResultHolder.pass(player.getItemInHand(hand));
+        return clientFunc(level, player, hand);
+    }
+}


### PR DESCRIPTION
Move client-related code into separate functions that will not persist on the server. `Screen` is client only class so if the server trying to load it, it cause crash. 

```
-- Head --
Thread: main
Suspected Mods: NONE
Stacktrace:
        at net.minecraftforge.fml.loading.RuntimeDistCleaner.processClassWithFlags(RuntimeDistCleaner.java:57) ~[fmlloader-1.20.1-47.2.20.jar%23103!/:1.0] {}
-- MOD create_radar --
Details:
        Caused by 0: java.lang.BootstrapMethodError: java.lang.RuntimeException: Attempted to load class net/minecraft/client/gui/screens/Screen for invalid dist DEDICATED_SERVER
                at com.happysg.radar.registry.ModItems.<clinit>(ModItems.java:18) ~[create_radar-0.3+mc1.20.1.jar%23237!/:0.3+mc1.20.1] {re:classloading}
                at com.happysg.radar.CreateRadar.<init>(CreateRadar.java:59) ~[create_radar-0.3+mc1.20.1.jar%23237!/:0.3+mc1.20.1] {re:classloading}
                at jdk.internal.reflect.DirectConstructorHandleAccessor.newInstance(DirectConstructorHandleAccessor.java:62) ~[?:?] {}
                at java.lang.reflect.Constructor.newInstanceWithCaller(Constructor.java:502) ~[?:?] {}
                at java.lang.reflect.Constructor.newInstance(Constructor.java:486) ~[?:?] {}
                at net.minecraftforge.fml.javafmlmod.FMLModContainer.constructMod(FMLModContainer.java:70) ~[javafmllanguage-1.20.1-47.2.20.jar%23279!/:?] {}
                at net.minecraftforge.fml.ModContainer.lambda$buildTransitionHandler$4(ModContainer.java:124) ~[fmlcore-1.20.1-47.2.20.jar%23278!/:?] {}
                at java.util.concurrent.CompletableFuture$AsyncRun.run(CompletableFuture.java:1804) ~[?:?] {}
                at java.util.concurrent.CompletableFuture$AsyncRun.exec(CompletableFuture.java:1796) ~[?:?] {}
                at java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:387) ~[?:?] {}
                at java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1310) ~[?:?] {}
                at java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1841) ~[?:?] {re:mixin,re:computing_frames}
                at java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1806) ~[?:?] {re:mixin,re:computing_frames}
                at java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:188) ~[?:?] {re:mixin}

        Mod File: /home/sanya-host/juan/rusha_serv/mods/create_radar-0.3+mc1.20.1.jar
        Failure message: Create: Radars (create_radar) has failed to load correctly
                java.lang.BootstrapMethodError: java.lang.RuntimeException: Attempted to load class net/minecraft/client/gui/screens/Screen for invalid dist DEDICATED_SERVER
        Mod Version: 0.3
        Mod Issue URL: NOT PROVIDED
        Exception message: java.lang.RuntimeException: Attempted to load class net/minecraft/client/gui/screens/Screen for invalid dist DEDICATED_SERVER
```