### PR TITLE
fix: throw NoClassDefFoundError while rendering radar tracks if VS2 is not load

### DIFF
--- a/src/main/java/com/happysg/radar/block/monitor/MonitorRenderer.java
+++ b/src/main/java/com/happysg/radar/block/monitor/MonitorRenderer.java
@@ -2,6 +2,7 @@ package com.happysg.radar.block.monitor;
 
 import com.happysg.radar.block.radar.behavior.IRadar;
 import com.happysg.radar.block.radar.track.RadarTrack;
+import com.happysg.radar.compat.Mods;
 import com.happysg.radar.compat.vs2.PhysicsHandler;
 import com.happysg.radar.compat.vs2.VS2Utils;
 import com.happysg.radar.config.RadarConfig;
@@ -237,7 +238,10 @@ public class MonitorRenderer extends SmartBlockEntityRenderer<MonitorBlockEntity
 
         // Calculate track position relative to radar
         Vec3 radarPos = PhysicsHandler.getWorldPos(monitor.getLevel(), radar.getWorldPos()).getCenter();
-        Vec3 relativePos = VS2Utils.getShipVecDirectionTransform(track.position().subtract(radarPos), monitor);;
+        Vec3 relativePos = track.position().subtract(radarPos);
+        if (Mods.VALKYRIENSKIES.isLoaded()) {
+            relativePos = VS2Utils.getShipVecDirectionTransform(relativePos, monitor);
+        }
         if (radar.renderRelativeToMonitor()) {
             //todo change for plane radar
         }


### PR DESCRIPTION
After I linked the radar monitor, the game crashed with NoClassDefFoundError. It seems like the renderTrack method called another method in VS2Utils class before checking compatibility.
```
Description: Rendering Block Entity

java.lang.NoClassDefFoundError: org/valkyrienskies/core/api/ships/Ship
	at com.happysg.radar.block.monitor.MonitorRenderer.renderTrack(MonitorRenderer.java:243) ~[main/:?] {re:classloading}
	at com.happysg.radar.block.monitor.MonitorRenderer.renderRadarTracks(MonitorRenderer.java:225) ~[main/:?] {re:classloading}
	at com.happysg.radar.block.monitor.MonitorRenderer.renderRadarDisplay(MonitorRenderer.java:99) ~[main/:?] {re:classloading}
	at com.happysg.radar.block.monitor.MonitorRenderer.lambda$renderSafe$0(MonitorRenderer.java:71) ~[main/:?] {re:classloading}
	at java.util.Optional.ifPresent(Optional.java:178) ~[?:?] {re:mixin}
	at com.happysg.radar.block.monitor.MonitorRenderer.renderSafe(MonitorRenderer.java:65) ~[main/:?] {re:classloading}
	at com.happysg.radar.block.monitor.MonitorRenderer.renderSafe(MonitorRenderer.java:31) ~[main/:?] {re:classloading}
	at com.simibubi.create.foundation.blockEntity.renderer.SafeBlockEntityRenderer.render(SafeBlockEntityRenderer.java:24) ~[create-1.20.1-6.0.4-79_mapped_parchment_2023.09.03-1.20.1.jar:?] {re:classloading}
	at net.minecraft.client.renderer.blockentity.BlockEntityRenderDispatcher.setupAndRender(BlockEntityRenderDispatcher.java:85) ~[forge-1.20.1-47.3.0_mapped_parchment_2023.09.03-1.20.1-recomp.jar:?] {re:classloading,pl:accesstransformer:B,pl:runtimedistcleaner:A}
    ...
Caused by: java.lang.ClassNotFoundException: org.valkyrienskies.core.api.ships.Ship
	at jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:641) ~[?:?] {}
	at java.lang.ClassLoader.loadClass(ClassLoader.java:526) ~[?:?] {}
	at cpw.mods.cl.ModuleClassLoader.loadClass(ModuleClassLoader.java:137) ~[securejarhandler-2.1.10.jar:?] {}
	at java.lang.ClassLoader.loadClass(ClassLoader.java:526) ~[?:?] {}
	at cpw.mods.cl.ModuleClassLoader.loadClass(ModuleClassLoader.java:137) ~[securejarhandler-2.1.10.jar:?] {}
	at java.lang.ClassLoader.loadClass(ClassLoader.java:526) ~[?:?] {}
	... 32 more
```