### PR TITLE
[fix] make VS2-only blocks optional in vanilla mineable tags

### DIFF
--- a/src/main/resources/data/minecraft/tags/blocks/mineable/axe.json
+++ b/src/main/resources/data/minecraft/tags/blocks/mineable/axe.json
@@ -4,8 +4,6 @@
     "create_radar:monitor",
     "create_radar:data_link",
     "create_radar:radar_bearing",
-    "create_radar:plane_radar",
-    "create_radar:identification_transponder",
     "create_radar:radar_receiver_block",
     "create_radar:radar_dish_block",
     "create_radar:radar_plate_block",
@@ -13,7 +11,6 @@
     "create_radar:auto_yaw_controller",
     "create_radar:auto_pitch_controller",
     "create_radar:fire_controller",
-    "create_radar:network_filterer",
-    "create_radar:radar_warning_receiver"
+    "create_radar:network_filterer"
   ]
 }

--- a/src/main/resources/data/minecraft/tags/blocks/mineable/axe.json
+++ b/src/main/resources/data/minecraft/tags/blocks/mineable/axe.json
@@ -11,6 +11,9 @@
     "create_radar:auto_yaw_controller",
     "create_radar:auto_pitch_controller",
     "create_radar:fire_controller",
-    "create_radar:network_filterer"
+    "create_radar:network_filterer",
+    { "id": "create_radar:plane_radar", "required": false },
+    { "id": "create_radar:identification_transponder", "required": false },
+    { "id": "create_radar:radar_warning_receiver", "required": false }
   ]
 }

--- a/src/main/resources/data/minecraft/tags/blocks/mineable/pickaxe.json
+++ b/src/main/resources/data/minecraft/tags/blocks/mineable/pickaxe.json
@@ -4,8 +4,6 @@
     "create_radar:monitor",
     "create_radar:data_link",
     "create_radar:radar_bearing",
-    "create_radar:plane_radar",
-    "create_radar:identification_transponder",
     "create_radar:radar_receiver_block",
     "create_radar:radar_dish_block",
     "create_radar:radar_plate_block",
@@ -13,7 +11,6 @@
     "create_radar:auto_yaw_controller",
     "create_radar:auto_pitch_controller",
     "create_radar:fire_controller",
-    "create_radar:network_filterer",
-    "create_radar:radar_warning_receiver"
+    "create_radar:network_filterer"
   ]
 }

--- a/src/main/resources/data/minecraft/tags/blocks/mineable/pickaxe.json
+++ b/src/main/resources/data/minecraft/tags/blocks/mineable/pickaxe.json
@@ -11,6 +11,9 @@
     "create_radar:auto_yaw_controller",
     "create_radar:auto_pitch_controller",
     "create_radar:fire_controller",
-    "create_radar:network_filterer"
+    "create_radar:network_filterer",
+    { "id": "create_radar:plane_radar", "required": false },
+    { "id": "create_radar:identification_transponder", "required": false },
+    { "id": "create_radar:radar_warning_receiver", "required": false }
   ]
 }


### PR DESCRIPTION
## Summary

`minecraft:mineable/pickaxe` and `minecraft:mineable/axe` listed three blocks that are only registered when Valkyrien Skies is loaded. Without VS2 those registry IDs are missing, so `TagLoader` rejects the whole tag and tools can mine like an empty hand.

This PR keeps the three entries but marks each as an optional tag reference (`"required": false`). Missing IDs are skipped when VS2 is absent, and the blocks stay in the mineable tags when they exist.

Closes #111 